### PR TITLE
Support de la balise <figure>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checklist-lodel",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checklist-lodel",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "OpenEdition Checklist Plugin for Lodel CMS",
   "private": true,
   "scripts": {},

--- a/public/js/rules-oeb.js
+++ b/public/js/rules-oeb.js
@@ -945,7 +945,7 @@ window.checklistRules = [
       var $bad = $field.find("a[href ^= '#id_']");
 
       // Orphan Text and Elements
-      var allowedTags = ["p", "h1", "h2", "h3", "h4", "h5", "h6", "ol", "ul", "pre", "address", "blockquote", "dl", "div", "hr", "table"];
+      var allowedTags = ["p", "h1", "h2", "h3", "h4", "h5", "h6", "ol", "ul", "pre", "address", "blockquote", "dl", "div", "hr", "table", "figure"];
       $field.contents().each(function () {
         var isElement = this.nodeType === 1;
         var isText = this.nodeType === 3;

--- a/public/js/rules-oej.js
+++ b/public/js/rules-oej.js
@@ -871,7 +871,7 @@ window.checklistRules = [
       var $bad = $field.find("a[href ^= '#id_']");
 
       // Orphan Text and Elements
-      var allowedTags = ["p", "h1", "h2", "h3", "h4", "h5", "h6", "ol", "ul", "pre", "address", "blockquote", "dl", "div", "hr", "table"];
+      var allowedTags = ["p", "h1", "h2", "h3", "h4", "h5", "h6", "ol", "ul", "pre", "address", "blockquote", "dl", "div", "hr", "table", "figure"];
       $field.contents().each(function () {
         var isElement = this.nodeType === 1;
         var isText = this.nodeType === 3;


### PR DESCRIPTION
Cette modif ajoute `<figure>` dans les balises acceptées par checklist.

Dans le cadre d'un chantier d'amélioration de l'accessibilité de nos maquettes, nous utilisons maintenant la balise `<figure>` pour afficher les images et leur légende : https://github.com/edinum/lodel-textfunc/blob/a98b60ce693d9d9b8dd80504943a860e67b429b6/illustrations.php

Actuellement cette modification active la règle texte:quality(champs), qui signale à tort la présence de champs Word dans les documents avec des images. Cette correction règle ce problème.

Je suis sûr à 99,99% que cela n'entrainera aucun problème sur les plateformes OEJ et OEB. Je passe quand même par une PR pour garder une trace de ce correctif et son explication.